### PR TITLE
Add Create Field Functionality with Farm Association

### DIFF
--- a/src/main/java/com/citronix/api/service/impl/FieldServiceImpl.java
+++ b/src/main/java/com/citronix/api/service/impl/FieldServiceImpl.java
@@ -8,6 +8,7 @@ import com.citronix.api.service.FarmService;
 import com.citronix.api.service.FieldService;
 import com.citronix.api.web.DTO.field.FieldCreateDTO;
 import com.citronix.api.web.DTO.field.FieldUpdateDTO;
+import com.citronix.api.web.exception.EntityNotFoundException;
 import com.citronix.api.web.mapper.FieldMapper;
 import org.springframework.stereotype.Service;
 
@@ -57,7 +58,8 @@ public class FieldServiceImpl implements FieldService {
 
     @Override
     public Field findById(Long id) {
-        return null;
+        return fieldRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Field with id : " + id + " not found"));
     }
 
     @Override

--- a/src/main/java/com/citronix/api/web/rest/FieldController.java
+++ b/src/main/java/com/citronix/api/web/rest/FieldController.java
@@ -9,10 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RequiredArgsConstructor
@@ -30,4 +27,10 @@ public class FieldController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @GetMapping("/fields/{id}")
+    public ResponseEntity<ResponseFieldVM> findById(@PathVariable Long id) {
+        Field field = fieldService.findById(id);
+        ResponseFieldVM response = fieldMapper.toResponseFieldVM(field);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 }


### PR DESCRIPTION
# Pull Request: Add Create Field Functionality with Farm Association

## Description

This pull request implements the functionality to create a new `Field` and associate it with an existing `Farm`. The feature enables developers to add fields with specific attributes such as name, area, and a reference to the farm it belongs to, ensuring proper validation and mapping between the request data and the domain model.

### Key Features
- **Create Field:** 
  - Accepts field creation data via a POST request.
  - Associates the field with an existing `Farm` identified by its `farmId`.
- **Validation:**
  - Ensures required fields (e.g., `name`, `area`, `farmId`) are provided and meet business constraints.
- **Response Mapping:**
  - Returns the newly created `Field` with its associated `Farm` details.

## Changes Introduced
- **`FieldController`**
  - Added the `create` method to handle incoming POST requests and delegate creation logic to the service layer.
  
- **`FieldService`**
  - Handles business logic for creating a new `Field` and validates field count and area constraints for the associated `Farm`.

- **`FieldMapper`**
  - Added mappings to transform between `FieldCreateDTO`, 
